### PR TITLE
rework sourcemap remapping to use callback function

### DIFF
--- a/packages/babel-parser/src/options.js
+++ b/packages/babel-parser/src/options.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { PluginList } from "./plugin-utils";
-import sourcemap from "source-map";
+import type { Position, SourceMapPosition } from "./util/location";
 
 // A second optional argument can be given to further configure
 // the parser process. These options are recognized:
@@ -23,6 +23,7 @@ export type Options = {
   tokens: boolean,
   createParenthesizedExpressions: boolean,
   errorRecovery: boolean,
+  remapOriginalPosition?: (position: Position) => SourceMapPosition,
 };
 
 export const defaultOptions: Options = {
@@ -67,20 +68,15 @@ export const defaultOptions: Options = {
   // When enabled, errors are attached to the AST instead of being directly thrown.
   // Some errors will still throw, because @babel/parser can't always recover.
   errorRecovery: false,
-  inputSourceMap: undefined,
+  remapOriginalPosition: undefined,
 };
 
 // Interpret and default an options object
 
-export function getOptions(opts: ?Options, input: string): Options {
+export function getOptions(opts: ?Options): Options {
   const options: any = {};
   for (const key of Object.keys(defaultOptions)) {
     options[key] = opts && opts[key] != null ? opts[key] : defaultOptions[key];
-  }
-  if(typeof options.inputSourceMap === 'object') {
-    options.inputSourceMap = new sourcemap.SourceMapConsumer(options.inputSourceMap);
-  } else if(options.inputSourceMap === true){
-    throw new Error("not implemented")
   }
   return options;
 }

--- a/packages/babel-parser/src/parser/index.js
+++ b/packages/babel-parser/src/parser/index.js
@@ -25,7 +25,7 @@ export default class Parser extends StatementParser {
   */
 
   constructor(options: ?Options, input: string) {
-    options = getOptions(options, input);
+    options = getOptions(options);
     super(options, input);
 
     const ScopeHandler = this.getScopeHandler();

--- a/packages/babel-parser/src/parser/node.js
+++ b/packages/babel-parser/src/parser/node.js
@@ -12,11 +12,12 @@ class Node implements NodeBase {
     this.type = "";
     this.start = pos;
     this.end = 0;
-    if(parser.options.inputSourceMap){
-      let {line, column, name, source} = parser.options.inputSourceMap.originalPositionFor(loc);
-      this.loc = new SourceLocation(new Position(line, column));
-      this.loc.filename = source;
-      this.loc.identifierName = name;
+
+    if(parser?.options.remapOriginalPosition){
+      let originalMapping = parser.options.remapOriginalPosition(loc);
+      this.loc = new SourceLocation(new Position(originalMapping.line, originalMapping.column));
+      if(originalMapping.source) this.loc.filename = originalMapping.source;
+      this.loc.identifierName = originalMapping.name;
     } else {
       this.loc = new SourceLocation(loc);
       if (parser?.filename) this.loc.filename = parser.filename;
@@ -98,9 +99,9 @@ export class NodeUtils extends UtilParser {
     }
     node.type = type;
     node.end = pos;
-    if(this.options.inputSourceMap){
-      let {line, column} = this.options.inputSourceMap.originalPositionFor(loc);
-      node.loc.end = new Position(line, column);
+    if(this.options.remapOriginalPosition){
+      let originalMapping = this.options.remapOriginalPosition(loc);
+      node.loc.end = new Position(originalMapping.line, originalMapping.column);
     } else {
       node.loc.end = loc;
     }
@@ -121,9 +122,9 @@ export class NodeUtils extends UtilParser {
     endLoc?: Position = this.state.lastTokEndLoc,
   ): void {
     node.end = end;
-    if(this.options.inputSourceMap){
-      let {line, column} = this.options.inputSourceMap.originalPositionFor(endLoc);
-      node.loc.end = new Position(line, column);
+    if(this.options.remapOriginalPosition){
+      let originalMapping = this.options.remapOriginalPosition(endLoc);
+      node.loc.end = new Position(originalMapping.line, originalMapping.column);
     } else {
       node.loc.end = endLoc;
     }

--- a/packages/babel-parser/src/util/location.js
+++ b/packages/babel-parser/src/util/location.js
@@ -2,6 +2,13 @@
 
 import { lineBreakG } from "./whitespace";
 
+export type SourceMapPosition = {
+  line: number;
+  column: number;
+  source?: ?string;
+  name?: ?string;
+};
+
 export type Pos = {
   start: number,
 };


### PR DESCRIPTION
# PR

Use callback function for remapping instead of inputSourceMap, I intentionally didn't wanna call it inputSourceMap to get rid of any confusion.

Not sure if the name is really good but it's a start.